### PR TITLE
Enh: not necessary to keep the value in objects_updated

### DIFF
--- a/tests/test_mongo_live_config.py
+++ b/tests/test_mongo_live_config.py
@@ -69,7 +69,6 @@ class SimpleTest(unittest.TestCase):
                       'host should have been added.')
         self.assertIn('host_name', objects[Host][host],
                       'host_name should be present in the host modified keys')
-        self.assertEqual('bla', objects[Host][host]['host_name'])
 
         conn = mod._connect_to_mongo()
         db = conn['shinken_live']


### PR DESCRIPTION
so use a set for storing the modified attributes.
and use getattr(obj, attr) to get the actual value when syncing with mongo.
